### PR TITLE
fix(news):image

### DIFF
--- a/src/components/NewsContent.astro
+++ b/src/components/NewsContent.astro
@@ -53,14 +53,11 @@ const { Content } = await render(article!);
     padding: 1em;
 
     img {
-      /* max-height: 90vh; */
-      /* max-width: 80vw; */
+      max-width: min(90vw, 100%);
+      max-height: 90vh;
       width: auto;
-      height: 90vh;
-      @media screen and (max-width: 768px) {
-        width: 80vw;
-        height: auto;
-      }
+      height: auto;
+      object-fit: contain;
       display: block;
       margin: auto;
     }


### PR DESCRIPTION
newsでのImage表示についてアスペクト比が崩れる問題の修正
既存のコードから画面サイズに応じて自動で調整するように変更
pcブラウザで正しく動くことは確認済